### PR TITLE
Fix python relative imports with aliases

### DIFF
--- a/languages/python/python.go
+++ b/languages/python/python.go
@@ -1,30 +1,42 @@
 package python
 
 import (
+	"strings"
+
 	sitter "github.com/smacker/go-tree-sitter"
 	"github.com/smacker/go-tree-sitter/python"
 	"github.com/src-d/imports/languages/tsitter"
 )
 
-const (
-	query = `
-		((import_statement name: (dotted_name (identifier)) @name))
-		((import_from_statement module_name: (dotted_name (identifier)) @name))
-		((import_from_statement module_name: (relative_import (import_prefix)) @name))
-		((import_from_statement module_name: (relative_import (import_prefix) (dotted_name (identifier))) @name))
-		((aliased_import name: (dotted_name (identifier)) @name))
-	`
-)
-
 var (
-	q *sitter.Query
+	query = []string{
+		`((import_statement name: (dotted_name (identifier)) @name))`,
+		`((import_statement name: (aliased_import name: (dotted_name (identifier)) @name)))`,
+		`((import_from_statement module_name: (dotted_name (identifier)) @name))`,
+		`((import_from_statement module_name: (relative_import (import_prefix)) @name))`,
+	}
+	q []*sitter.Query
+
+	dQuery    = `((call function: (identifier) @fn arguments: (argument_list (string) @arg)))`
+	dFnFilter = map[string]struct{}{
+		"__import__":  struct{}{},
+		"import_file": struct{}{},
+	}
+	dq *sitter.Query
 )
 
 func init() {
 	tsitter.RegisterLanguage(language{})
 
 	var err error
-	if q, err = sitter.NewQuery([]byte(query), python.GetLanguage()); err != nil {
+	q = make([]*sitter.Query, len(query))
+	for i, qi := range query {
+		if q[i], err = sitter.NewQuery([]byte(qi), python.GetLanguage()); err != nil {
+			panic(err)
+		}
+	}
+
+	if dq, err = sitter.NewQuery([]byte(dQuery), python.GetLanguage()); err != nil {
 		panic(err)
 	}
 }
@@ -40,20 +52,60 @@ func (l language) GetLanguage() *sitter.Language {
 }
 
 func (l language) Imports(content []byte, root *sitter.Node) ([]string, error) {
-	var out []string
+	var out = []string{}
+
+	// regular imports (import_statement, import_from_statement)
+	for _, qi := range q {
+		out = append(out, imports(content, root, qi)...)
+	}
+
+	// dynamic imports (call function)
+	out = append(out, dImports(content, root, dq, dFnFilter)...)
+
+	return out, nil
+}
+
+func imports(content []byte, root *sitter.Node, query *sitter.Query) []string {
+	var out = []string{}
+
 	c := sitter.NewQueryCursor()
-	c.Exec(q, root)
+	c.Exec(query, root)
 	for {
 		m, ok := c.NextMatch()
 		if !ok {
 			break
 		}
 
-		for _, cap := range m.Captures {
-			str := string(content[cap.Node.StartByte():cap.Node.EndByte()])
+		if len(m.Captures) == 1 {
+			n := m.Captures[0].Node
+			str := string(content[n.StartByte():n.EndByte()])
 			out = append(out, str)
 		}
 	}
 
-	return out, nil
+	return out
+}
+
+func dImports(content []byte, root *sitter.Node, query *sitter.Query, filter map[string]struct{}) []string {
+	var out = []string{}
+
+	c := sitter.NewQueryCursor()
+	c.Exec(query, root)
+	for {
+		m, ok := c.NextMatch()
+		if !ok {
+			break
+		}
+		if len(m.Captures) == 2 {
+			capFn, capArg := m.Captures[0], m.Captures[1]
+
+			fn := string(content[capFn.Node.StartByte():capFn.Node.EndByte()])
+			if _, ok := filter[fn]; ok {
+				arg := string(content[capArg.Node.StartByte():capArg.Node.EndByte()])
+				out = append(out, strings.Trim(arg, `'"`))
+			}
+		}
+	}
+
+	return out
 }

--- a/languages/python/python_test.go
+++ b/languages/python/python_test.go
@@ -66,26 +66,26 @@ func TestPythonImports(t *testing.T) {
 				"...",
 			},
 		},
-		// {
-		// 	Name: "relative named",
-		// 	Src: `
-		// 		from a.b import x as b
-		// 	`,
-		// 	Exp: []string{
-		// 		"a.b",
-		// 	},
-		// },
-		// {
-		// 	Name: "relative named",
-		// 	Src: `
-		// 		from a.b import x as b
-		// 		from A.B import X as B
-		// 	`,
-		// 	Exp: []string{
-		// 		"A.B",
-		// 		"a.b",
-		// 	},
-		// },
+		{
+			Name: "relative named",
+			Src: `
+				from a.b import x as b
+			`,
+			Exp: []string{
+				"a.b",
+			},
+		},
+		{
+			Name: "relative named",
+			Src: `
+				from a.b import x as b
+				from A.B import X as B
+			`,
+			Exp: []string{
+				"A.B",
+				"a.b",
+			},
+		},
 		{
 			Name: "relative symbols",
 			Src:  `from a.b import x, y`,
@@ -105,9 +105,37 @@ func TestPythonImports(t *testing.T) {
 		},
 		{
 			Name: "dynamic",
-			Src:  `__import__('/a/b/c')`,
-			Exp:  []string{
-				//"/a/b/c", // TODO: dynamic imports
+			Src: `
+				__import__('/a/b/c')
+				another = import_file('relative_subdir/another.py')
+				`,
+			Exp: []string{
+				"/a/b/c",
+				"relative_subdir/another.py",
+			},
+		},
+		{
+			Name: "all",
+			Src: `
+				import a.b
+				import c.d as x
+				from ... import x
+				from e.f import x as g
+				from h.i import x, y
+				from j.k import x,y
+				from a.b import baz
+				__import__('/a/b/c')
+				another = import_file('d/e/f/g')
+				`,
+			Exp: []string{
+				"...",
+				"/a/b/c",
+				"a.b",
+				"c.d",
+				"d/e/f/g",
+				"e.f",
+				"h.i",
+				"j.k",
 			},
 		},
 	})


### PR DESCRIPTION
Signed-off-by: kuba-- <kuba@sourced.tech>

This PR fixes python relative imports with aliases, e.g.: `from a.b import x as b`
Now we check only first query which satisfies import, so in this case we check `import_from_statement` and don't check the next one `aliased_import`, what would append `x`.